### PR TITLE
add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: install dependencies
+        run: apt update && apt install -y gnupg wget meson cmake pkg-config libssl-dev git clang
+      - name: install llvm
+        run: wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -;
+          echo 'deb http://apt.llvm.org/bookworm/   llvm-toolchain-bookworm-17  main' >> /etc/apt/sources.list;
+          apt update;
+          apt install -y llvm-17;
+          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-17 17;
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: build release
+        run: mkdir build; meson build -Dbuildtype=release; ninja -C build
+      - name: test release
+        run: ninja -C build test
+      - name: bundle artifacts
+        run: tar -czf instrew-x86.tar.gz build/client build/server
+      - name: delete-previous-release
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 0
+          delete_tags: true
+          delete_tag_pattern: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: latest_release
+          release_name: latest
+          draft: true
+          prerelease: false
+      - name: upload release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./instrew-x86.tar.gz
+          asset_name: instrew-x86.tar.gz
+          asset_content_type: application/gzip
+      - name: publish release
+        id: publish_release
+        uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}


### PR DESCRIPTION
## why
The readme file doesn't give a lot of info on what dependencies (libssl, llvm, etc) are necessary to build the project. I figured it out and wanted to save others the trouble
- users don't need to configure build environment and dependencies to try out the project because they can simply download from the [releases page](https://github.com/mcrossen/instrew/releases)
- users can follow the same steps as the build automation to setup a working environment on a fresh docker image of ubuntu:22.04

## be aware
The automation currently doesn't trigger according to any schedule; instead, there's a button in the 'actions' tab of the repo anytime you want to release a new version. It deletes the old version automatically to not count against your quota. If you want, I can change this behavior or I can set it up to automatically release weekly, monthly, when main branch is pushed or something.

I'm still somewhat new to github actions so perhaps there's a more elegant way to accomplish this. But hey, it works!

## future
in the future, i think it could be cool to release ARM artifacts. To do that, either github would need to widely support ARM host types for action workflows or someone could figure out how to configure meson for cross-compilation.