### PR TITLE
add release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,52 +1,78 @@
 name: Release
 on: workflow_dispatch
 jobs:
-  release:
+  create-release:
     runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create.outputs.id }}
+      release_url: ${{ steps.create.outputs.upload_url }}
+    steps: 
+      - name: create release
+        id: create
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: latest
+          release_name: latest
+          draft: true
+          prerelease: false
+  build:
+    needs: create-release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: ["amd64", "arm64/v8"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
       - name: build docker environment
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/${{ matrix.platform }}
           push: false
           tags: instrew-env
       - name: build instrew
         run: docker run --rm -v "$PWD"/:/instrew/ instrew-env
-      - name: bundle instrew
-        run: mv install instrew && tar -czf instrew-x86_64.tar.gz instrew
-      - name: create release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: generate artifact name
+        uses: mad9000/actions-find-and-replace-string@5
+        id: artifact-name
         with:
-          tag_name: latest_release
-          release_name: latest
-          draft: true
-          prerelease: false
+          source: instrew-${{ matrix.platform }}.tar.gz
+          find: '/'
+          replace: ''
+      - name: bundle instrew
+        run: mv install instrew && tar -czf ${{ steps.artifact-name.outputs.value }} instrew
       - name: upload release
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./instrew-x86_64.tar.gz
-          asset_name: instrew-x86_64.tar.gz
+          upload_url: ${{ needs.create-release.outputs.release_url }}
+          asset_path: ./${{ steps.artifact-name.outputs.value }}
+          asset_name: ${{ steps.artifact-name.outputs.value }}
           asset_content_type: application/gzip
+  publish-release:
+    needs:
+      - create-release
+      - build
+    runs-on: ubuntu-latest
+    steps:
+      - name: delete-previous-release
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 0
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: publish release
         uses: eregon/publish-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          release_id: ${{ steps.create_release.outputs.id }}
-      - name: delete-previous-release
-        uses: dev-drprasad/delete-older-releases@v0.2.0
-        with:
-          keep_latest: 1
-          delete_tags: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          release_id: ${{ needs.create-release.outputs.release_id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+on: workflow_dispatch
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: ubuntu:24.04
+    steps:
+      - name: install dependencies
+        run: apt update && apt install -y gnupg wget meson cmake pkg-config libssl-dev git clang
+      - name: install llvm
+        run: wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -;
+          echo 'deb http://apt.llvm.org/bookworm/   llvm-toolchain-bookworm-17  main' >> /etc/apt/sources.list;
+          apt update;
+          apt install -y llvm-17;
+          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-17 17;
+      - name: checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: build release
+        run: mkdir build; meson build -Dbuildtype=release; ninja -C build
+      - name: test release
+        run: ninja -C build test
+      - name: bundle artifacts
+        run: tar -czf instrew-x86.tar.gz build/client build/server
+      - name: delete-previous-release
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 0
+          delete_tags: true
+          delete_tag_pattern: latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: latest_release
+          release_name: latest
+          draft: true
+          prerelease: false
+      - name: upload release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./instrew-x86.tar.gz
+          asset_name: instrew-x86.tar.gz
+          asset_content_type: application/gzip
+      - name: publish release
+        id: publish_release
+        uses: eregon/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_id: ${{ steps.create_release.outputs.id }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,34 +3,21 @@ on: workflow_dispatch
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: ubuntu:24.04
     steps:
-      - name: install dependencies
-        run: apt update && apt install -y gnupg wget meson cmake pkg-config libssl-dev git clang
-      - name: install llvm
-        run: wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -;
-          echo 'deb http://apt.llvm.org/bookworm/   llvm-toolchain-bookworm-17  main' >> /etc/apt/sources.list;
-          apt update;
-          apt install -y llvm-17;
-          update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-17 17;
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: true
-      - name: build release
-        run: mkdir build; meson build -Dbuildtype=release; ninja -C build
-      - name: test release
-        run: ninja -C build test
-      - name: bundle artifacts
-        run: tar -czf instrew-x86.tar.gz build/client build/server
-      - name: delete-previous-release
-        uses: dev-drprasad/delete-older-releases@v0.2.0
+      - name: build docker environment
+        uses: docker/build-push-action@v5
         with:
-          keep_latest: 0
-          delete_tags: true
-          delete_tag_pattern: latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          context: .
+          push: false
+          tags: instrew-env
+      - name: build instrew
+        run: docker run --rm -v "$PWD"/:/instrew/ instrew-env
+      - name: bundle instrew
+        run: mv install instrew && tar -czf instrew-x86_64.tar.gz instrew
       - name: create release
         id: create_release
         uses: actions/create-release@v1
@@ -47,13 +34,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./instrew-x86.tar.gz
-          asset_name: instrew-x86.tar.gz
+          asset_path: ./instrew-x86_64.tar.gz
+          asset_name: instrew-x86_64.tar.gz
           asset_content_type: application/gzip
       - name: publish release
-        id: publish_release
         uses: eregon/publish-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_id: ${{ steps.create_release.outputs.id }}
+      - name: delete-previous-release
+        uses: dev-drprasad/delete-older-releases@v0.2.0
+        with:
+          keep_latest: 1
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /*.sublime-*
-/build*
+/build/*
 /install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# build this docker image for a clean environemnt to build instrew
+FROM ubuntu:24.04
+
+# install dependencies
+RUN apt update \
+    && apt install -y gnupg wget meson cmake pkg-config libssl-dev clang
+
+# install LLVM
+RUN wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -\
+    && echo 'deb http://apt.llvm.org/bookworm/   llvm-toolchain-bookworm-17  main' >> /etc/apt/sources.list \
+    && apt update \
+    && apt install -y llvm-17 \
+    && update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-17 17
+
+# create mount point for project
+RUN mkdir /instrew/
+
+# build and test project
+WORKDIR /instrew/
+CMD /instrew/build.sh

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Instrew is a performance-targeted transparent dynamic binary translator(/instrum
 After cloning and checking out submodules, compile Instrew as follows:
 
 ```
-mkdir build
-meson build -Dbuildtype=release
-ninja -C build
-# optionally, run tests
-ninja -C build test
+./build.sh
+```
+
+If your build has dependency issues, consider using the provided dockerfile
+```
+docker build . --tag instrew-env # run once
+docker run --rm -v "$PWD"/:/instrew instrew-env # run to build instrew
 ```
 
 Afterwards, you can run an application with Instrew. Statically linked applications often have a significantly lower translation time. New glibc versions often tend to use recent syscalls that are not yet supported, therefore warnings about missing system calls can sometimes be ignored.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+mkdir -p build
+meson build -Dprefix="$PWD"/install -Dbuildtype=release
+ninja -C build
+ninja -C build test
+ninja -C build install


### PR DESCRIPTION
similar to my [other pull request](https://github.com/aengelke/instrew/pull/12) except improved to support arm through docker.

## benefits

The readme file doesn't give a lot of info on what dependencies (libssl, llvm, etc) are necessary to build the project. I figured it out (before seeing the [.builds](https://github.com/aengelke/instrew/blob/master/.builds/llvm15-x86_64-debian.yml) directory) and wanted to save others some trouble. 
- users don't need to configure build environment and dependencies to try out the project because they can simply download from the [releases page](https://github.com/mcrossen/instrew/releases)
- users can reuse the docker image to build in case their environments aren't working for them
- users can follow the steps in the dockerfile to setup a working environment

## how
There's two sides to this automation: docker and github actions

First, docker sets up a reusable environment to build instrew under. This is portable to other people's machines. Docker combined with an emulation layer is also used to build the ARM release.

Second, github actions automates the process of building and publishing releases to github's [releases](https://github.com/mcrossen/instrew/releases) page. The automation currently doesn't trigger according to any schedule; instead, there's a button in the 'actions' tab of the repo anytime you want to release a new version. It deletes the old version automatically to not count against your quota. If you want, I can change this behavior or I can set it up to automatically release weekly, monthly, when main branch is pushed or something.